### PR TITLE
ActiveModel type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+* Add ActiveModel type for date range:
+
+  ```
+  attribute :period, :date_range
+  ```
+
+  *Edwin Vlieg*
+
 ## 0.2.0
 
 * Add support for weeks:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activemodel (6.1.3.2)
+      activesupport (= 6.1.3.2)
     activesupport (6.1.3.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -128,6 +130,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_date_range!
+  activemodel
   guard
   guard-minitest
   minitest (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ date_range.humanize(format: :explicit)   # => 'January 1st, 2021 - December 31st
 
 See [active_date_range/locale/en.yml](https://github.com/moneybird/active-date-range/blob/main/lib/active_date_range/locale/en.yml) for all the I18n keys you need to translate for your application.
 
+### ActiveModel type
+
+Date ranges are also available as an ActiveModel type. So you can use a date range attribute and the value will automatically be converted:
+
+```ruby
+class Report
+  include ActiveModel::Attributes
+
+  attribute :period, :date_range
+end
+```
+
 ### Usage example
 
 Use the shorthands to link to a specific period:

--- a/active_date_range.gemspec
+++ b/active_date_range.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-packaging"
   spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "rubocop-rails"
+  spec.add_development_dependency "activemodel"
 end

--- a/lib/active_date_range.rb
+++ b/lib/active_date_range.rb
@@ -11,6 +11,7 @@ require "active_date_range/core_ext/date"
 require "active_date_range/version"
 require "active_date_range/date_range"
 require "active_date_range/humanizer"
+require "active_date_range/active_model_type"
 
 module ActiveDateRange
   class Error < StandardError; end

--- a/lib/active_date_range/active_model_type.rb
+++ b/lib/active_date_range/active_model_type.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ActiveDateRange
+  class DateRangeType < ActiveModel::Type::String
+    def cast(value)
+      ActiveDateRange::DateRange.parse(value)
+    end
+  end
+end
+
+if defined?(ActiveModel)
+  ActiveModel::Type.register(:date_range, ActiveDateRange::DateRangeType)
+end

--- a/test/active_date_range/active_model_type_test.rb
+++ b/test/active_date_range/active_model_type_test.rb
@@ -4,7 +4,6 @@ require "active_model"
 require "test_helper"
 
 class ActiveDateRangeAttributesTest < ActiveSupport::TestCase
-
   class TestReport
     include ActiveModel::Attributes
 

--- a/test/active_date_range/active_model_type_test.rb
+++ b/test/active_date_range/active_model_type_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "active_model"
+require "test_helper"
+
+class ActiveDateRangeAttributesTest < ActiveSupport::TestCase
+
+  class TestReport
+    include ActiveModel::Attributes
+
+    attribute :period, :date_range
+  end
+
+  def test_date_range_conversion
+    report = TestReport.new
+    report.period = "this_month"
+    assert_equal ActiveDateRange::DateRange.this_month, report.period
+  end
+
+  def test_date_range_conversion_error
+    report = TestReport.new
+    report.period = "unknown"
+    assert_raises(ActiveDateRange::InvalidDateRangeFormat) { report.period }
+  end
+end


### PR DESCRIPTION
Registers a `ActiveModel` type for date range, so it can be used as an attribute:

```
class Report
  include ActiveModel::Attributes

  attribute :period, :date_range
end
```