### PR TITLE
Include? behaves like cover?

### DIFF
--- a/lib/active_date_range/date_range.rb
+++ b/lib/active_date_range/date_range.rb
@@ -343,6 +343,10 @@ module ActiveDateRange
       DateRange.new(intersection) if intersection.any?
     end
 
+    def include?(other)
+      cover?(other)
+    end
+
     private
       def grouped_collection(granularity, amount: 1)
         raise UnknownGranularity, "Unknown granularity #{granularity}. Valid are: month, quarter and year" unless %w[month quarter year].include?(granularity.to_s)

--- a/test/active_date_range/date_range_test.rb
+++ b/test/active_date_range/date_range_test.rb
@@ -447,5 +447,10 @@ class ActiveDateRangeDateRangeTest < ActiveSupport::TestCase
 
   def test_include
     assert described_class.this_year.include?(Date.current)
+    assert described_class.this_year.include?(Date.current.at_beginning_of_year)
+    assert described_class.this_year.include?(Date.current.at_end_of_year)
+    assert_not described_class.prev_year.include?(Date.current)
+    assert_not described_class.this_year.include?(Date.current.at_beginning_of_year - 1.day)
+    assert_not described_class.this_year.include?(Date.current.at_end_of_year + 1.day)
   end
 end

--- a/test/active_date_range/date_range_test.rb
+++ b/test/active_date_range/date_range_test.rb
@@ -444,4 +444,8 @@ class ActiveDateRangeDateRangeTest < ActiveSupport::TestCase
     assert_raises(ActiveDateRange::BoundlessRangeError) { boundless.next }
     assert_raises(ActiveDateRange::BoundlessRangeError) { boundless.previous }
   end
+
+  def test_include
+    assert described_class.this_year.include?(Date.current)
+  end
 end


### PR DESCRIPTION
Ruby `Range` has different implementations for `include?` and `cover?`:

- `include?` will try to find the element in the range. Only when `begin` and `end` are numeric, it will behave like `cover?`:

> If begin and end are numeric, include? behaves like cover?

- `cover?` will test if the element is between `begin` and `end`:

> This tests `begin <= obj <= end` when exclude_end? is false and `begin <= obj < end` when exclude_end? is true.

There is a clear performance benefit from using `cover?` instead of `include?`. For ranges of dates, it is better to use `cover?`, because we have a continuous spectrum of dates. Therefore, the `include?` method now always calls `cover?` to have the performance benefit from it:


```ruby
range = ActiveDateRange::DateRange.this_year
day = Date.current

Benchmark.bm do |x|
  x.report("include?") { 1000.times { range.include?(day) } }
  x.report("cover?") { 1000.times { range.cover?(day) } }
  x.report("begin <= obj <= end") { 1000.times { day >= range.begin && day <= range.end } }
end
```

```
       user     system      total        real
include?  0.127010   0.004048   0.131058 (  0.132353)
cover?  0.000215   0.000000   0.000215 (  0.000215)
begin <= obj <= end  0.000264   0.000000   0.000264 (  0.000265)
```