### PR TITLE
Bump nokogiri (security advisory)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,10 +95,10 @@ GEM
     mini_portile2 (2.8.9)
     minitest (5.27.0)
     nenv (0.3.0)
-    nokogiri (1.19.1)
+    nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.19.1-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -218,4 +218,4 @@ DEPENDENCIES
   rubocop-rails (~> 2.33)
 
 BUNDLED WITH
-   2.3.5
+   2.6.9


### PR DESCRIPTION
Bumps nokogiri to 1.19.4 (moneybird/security-advisory-monitor#5479).