### PR TITLE
Bump concurrent-ruby to 1.3.7 (security)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     bigdecimal (4.0.1)
     builder (3.3.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)


### PR DESCRIPTION
Bumps concurrent-ruby to 1.3.7.

Fixes moneybird/security-advisory-monitor#5482.