### PR TITLE
Add DateRange.safe_parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ DateRange.safe_parse("test")           # => nil
 DateRange.safe_parse("202112..202101") # => nil
 ```
 
-  *Wessel Schoppers*
+  *wesselmoneybird*
+
+* Add a `safe: true` option to the `:date_range` ActiveModel type, which casts to `nil` instead of raising. Use it for attributes fed by input you don't control, so a validation can report the problem:
+
+```ruby
+attribute :period, :date_range, safe: true
+```
+
+  *wesselmoneybird*
 
 ## 0.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ```ruby
 DateRange.safe_parse("202101..202112") # => DateRange(2021-01-01..2021-12-31)
-DateRange.safe_parse("banana")         # => nil
+DateRange.safe_parse("test")           # => nil
 DateRange.safe_parse("202112..202101") # => nil
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.5.3
+
+* Add `safe_parse`, which returns `nil` instead of raising for input that isn't a valid date range. Use it for input you don't control, like a query parameter or a form field:
+
+```ruby
+DateRange.safe_parse("202101..202112") # => DateRange(2021-01-01..2021-12-31)
+DateRange.safe_parse("banana")         # => nil
+DateRange.safe_parse("202112..202101") # => nil
+```
+
+  *Wessel Schoppers*
+
 ## 0.5.2
 
 * Add calendar-aware `DateRangeValidator` for ActiveModel validations. Unlike `validates_length_of` which compares day counts (causing `1.month` to use ~30.44 day averages), this validator uses date arithmetic so that February (28 or 29 days) correctly satisfies `minimum_duration: 1.month`:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_date_range (0.5.2)
+    active_date_range (0.5.3)
       activesupport (~> 8.0)
       i18n (~> 1.6)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ ActiveDateRange::DateRange.parse('20210101..20210115')
 
 Parse accepts three formats: `YYYYMM..YYYYMM`, `YYYYMMDD..YYYYMMDD` and any short hand like `this_month`.
 
+`parse` raises `InvalidDateRangeFormat` or `InvalidDateRange` on input it can't handle. For input you don't control, like a query parameter or a form field, use `safe_parse` instead. It returns `nil` in those cases, the same way `safe_constantize` relates to `constantize`:
+
+```ruby
+ActiveDateRange::DateRange.safe_parse('202101..202112') # => DateRange(2021-01-01..2021-12-31)
+ActiveDateRange::DateRange.safe_parse('banana')         # => nil
+ActiveDateRange::DateRange.safe_parse('202112..202101') # => nil
+```
+
 ### The date range instance
 
 A `DateRange` object is an extension of a regular `Range` object. You can use [all methods available on `Range`](https://ruby-doc.org/core-3.0.0/Range.html):

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Parse accepts three formats: `YYYYMM..YYYYMM`, `YYYYMMDD..YYYYMMDD` and any shor
 
 ```ruby
 ActiveDateRange::DateRange.safe_parse('202101..202112') # => DateRange(2021-01-01..2021-12-31)
-ActiveDateRange::DateRange.safe_parse('banana')         # => nil
+ActiveDateRange::DateRange.safe_parse('test')           # => nil
 ActiveDateRange::DateRange.safe_parse('202112..202101') # => nil
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ class Report
 end
 ```
 
+The attribute raises on a value it can't parse. For an attribute fed by input you don't control, like a query parameter or a form field, pass `safe: true`. The attribute then casts to `nil` instead, so a validation can report the problem:
+
+```ruby
+class ReportFilter
+  include ActiveModel::Attributes
+  include ActiveModel::Validations
+
+  attribute :period, :date_range, safe: true
+
+  validates :period, date_range: { bounded: true }
+end
+
+ReportFilter.new(period: "test").period # => nil
+```
+
 ### Usage example
 
 Use the shorthands to link to a specific period:

--- a/lib/active_date_range/active_model_type.rb
+++ b/lib/active_date_range/active_model_type.rb
@@ -2,8 +2,17 @@
 
 module ActiveDateRange
   class DateRangeType < ActiveModel::Type::String
+    # Pass <tt>safe: true</tt> for attributes fed by input you don't control, like a query
+    # parameter. The attribute then casts to nil instead of raising:
+    #
+    #   attribute :period, :date_range, safe: true
+    def initialize(safe: false)
+      @safe = safe
+      super()
+    end
+
     def cast(value)
-      ActiveDateRange::DateRange.parse(value)
+      @safe ? ActiveDateRange::DateRange.safe_parse(value) : ActiveDateRange::DateRange.parse(value)
     end
   end
 end

--- a/lib/active_date_range/date_range.rb
+++ b/lib/active_date_range/date_range.rb
@@ -46,7 +46,7 @@ module ActiveDateRange
     # input you don't control, like a query parameter or a form field.
     #
     #   DateRange.safe_parse("202101..202112") # => DateRange(2021-01-01..2021-12-31)
-    #   DateRange.safe_parse("banana")         # => nil
+    #   DateRange.safe_parse("test")           # => nil
     #   DateRange.safe_parse("202112..202101") # => nil
     def self.safe_parse(input)
       parse(input)

--- a/lib/active_date_range/date_range.rb
+++ b/lib/active_date_range/date_range.rb
@@ -41,6 +41,19 @@ module ActiveDateRange
       DateRange.new(parse_date(begin_date), parse_date(end_date, last: true))
     end
 
+    # Parses a date range string like #parse, but returns nil when the input isn't a valid date
+    # range, the same way <tt>safe_constantize</tt> relates to <tt>constantize</tt>. Use this for
+    # input you don't control, like a query parameter or a form field.
+    #
+    #   DateRange.safe_parse("202101..202112") # => DateRange(2021-01-01..2021-12-31)
+    #   DateRange.safe_parse("banana")         # => nil
+    #   DateRange.safe_parse("202112..202101") # => nil
+    def self.safe_parse(input)
+      parse(input)
+    rescue InvalidDateRangeFormat, InvalidDateRange
+      nil
+    end
+
     def self.parse_date(input, last: false)
       return if input.blank?
 

--- a/lib/active_date_range/version.rb
+++ b/lib/active_date_range/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveDateRange
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
 end

--- a/test/active_date_range/active_model_type_test.rb
+++ b/test/active_date_range/active_model_type_test.rb
@@ -21,4 +21,28 @@ class ActiveDateRangeAttributesTest < ActiveSupport::TestCase
     report.period = "unknown"
     assert_raises(ActiveDateRange::InvalidDateRangeFormat) { report.period }
   end
+
+  class SafeTestReport
+    include ActiveModel::Attributes
+
+    attribute :period, :date_range, safe: true
+  end
+
+  def test_safe_date_range_conversion
+    report = SafeTestReport.new
+    report.period = "this_month"
+    assert_equal ActiveDateRange::DateRange.this_month, report.period
+  end
+
+  def test_safe_date_range_conversion_returns_nil
+    report = SafeTestReport.new
+    report.period = "unknown"
+    assert_nil report.period
+  end
+
+  def test_safe_date_range_conversion_returns_nil_for_reversed_range
+    report = SafeTestReport.new
+    report.period = "202503..202501"
+    assert_nil report.period
+  end
 end

--- a/test/active_date_range/date_range_test.rb
+++ b/test/active_date_range/date_range_test.rb
@@ -125,6 +125,18 @@ class ActiveDateRangeDateRangeTest < ActiveSupport::TestCase
     end
   end
 
+  def test_safe_parse
+    assert_equal described_class.new(Date.new(2021, 1, 1), Date.new(2021, 12, 31)), described_class.safe_parse(Date.new(2021, 1, 1)..Date.new(2021, 12, 31))
+    assert_equal described_class.new(Date.new(2013, 5, 1), Date.new(2013, 9, 1).at_end_of_month), described_class.safe_parse("201305..201309")
+    assert_equal described_class.new(Date.new(2014, 4, 15), Date.new(2014, 5, 23)), described_class.safe_parse("20140415..20140523")
+    assert_equal described_class.prev_year, described_class.safe_parse("prev_year")
+    assert_nil described_class.safe_parse(nil)
+    %w[2012..2013 2013011..2013051 foobar month 20-1301..20-1305 20160925..20160931].each do |format|
+      assert_nil described_class.safe_parse(format)
+    end
+    assert_nil described_class.safe_parse("202503..202501")
+  end
+
   def test_addition
     a = described_class.new(Date.new(2021, 1, 1)..Date.new(2021, 1, 31))
     b = described_class.new(Date.new(2021, 2, 1)..Date.new(2021, 2, 28))


### PR DESCRIPTION
`DateRange.parse` raises `InvalidDateRangeFormat` or `InvalidDateRange` on input it can't read. That is right for input you control, but not for a query parameter or a form field, where an invalid value is normal rather than exceptional. Every caller then has to rescue two gem-specific error classes to do anything sensible with it, which means a hand-edited date range in a URL takes down the page unless the application remembers to catch both.

`safe_parse` returns `nil` in those cases, the same way `safe_constantize` relates to `constantize`:

```ruby
DateRange.safe_parse("202101..202112") # => DateRange(2021-01-01..2021-12-31)
DateRange.safe_parse("test")           # => nil
DateRange.safe_parse("202112..202101") # => nil
```

Both error classes are covered: `InvalidDateRangeFormat` for input it cannot read, and `InvalidDateRange` for a range that ends before it begins. Anything else still raises, `safe_parse(5)` is a programming error, not invalid user input.

The `:date_range` ActiveModel type takes a `safe: true` option for the same reason, so an attribute fed by untrusted input casts to `nil` and a validation can report the problem:

```ruby
attribute :period, :date_range, safe: true
```
