### PR TITLE
Rename the safe: option to safe_parse:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.4
+
+* Rename the `safe:` option on the `:date_range` ActiveModel type to `safe_parse:`. On an attribute, `safe: true` reads as a claim that the value is trusted, while it actually describes how the value is parsed. `safe:` keeps working but is deprecated and will be removed in 0.6.0:
+
+```ruby
+attribute :period, :date_range, safe_parse: true
+```
+
+  *wesselmoneybird*
+
 ## 0.5.3
 
 * Add `safe_parse`, which returns `nil` instead of raising for input that isn't a valid date range. Use it for input you don't control, like a query parameter or a form field:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.5.4
 
-* Rename the `safe:` option on the `:date_range` ActiveModel type to `safe_parse:`. On an attribute, `safe: true` reads as a claim that the value is trusted, while it actually describes how the value is parsed. `safe:` keeps working but is deprecated and will be removed in 0.6.0:
+* Rename the `safe:` option on the `:date_range` ActiveModel type to `safe_parse:`. On an attribute, `safe: true` reads as a claim that the value is trusted, while it actually describes how the value is parsed. `safe:` keeps working but is deprecated and will be removed in a future version:
 
 ```ruby
 attribute :period, :date_range, safe_parse: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.5.4
+## 0.6.0
 
-* Rename the `safe:` option on the `:date_range` ActiveModel type to `safe_parse:`. On an attribute, `safe: true` reads as a claim that the value is trusted, while it actually describes how the value is parsed. `safe:` keeps working but is deprecated and will be removed in a future version:
+* **Breaking:** rename the `safe:` option on the `:date_range` ActiveModel type to `safe_parse:`. On an attribute, `safe: true` reads as a claim that the value is trusted, while it actually describes how the value is parsed. The option was introduced in 0.5.3 and `safe:` now raises an `ArgumentError`:
 
 ```ruby
 attribute :period, :date_range, safe_parse: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_date_range (0.5.4)
+    active_date_range (0.6.0)
       activesupport (~> 8.0)
       i18n (~> 1.6)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_date_range (0.5.3)
+    active_date_range (0.5.4)
       activesupport (~> 8.0)
       i18n (~> 1.6)
 

--- a/README.md
+++ b/README.md
@@ -134,14 +134,14 @@ class Report
 end
 ```
 
-The attribute raises on a value it can't parse. For an attribute fed by input you don't control, like a query parameter or a form field, pass `safe: true`. The attribute then casts to `nil` instead, so a validation can report the problem:
+The attribute raises on a value it can't parse. For an attribute fed by input you don't control, like a query parameter or a form field, pass `safe_parse: true`. The attribute then casts through `safe_parse`, so it returns `nil` instead and a validation can report the problem:
 
 ```ruby
 class ReportFilter
   include ActiveModel::Attributes
   include ActiveModel::Validations
 
-  attribute :period, :date_range, safe: true
+  attribute :period, :date_range, safe_parse: true
 
   validates :period, date_range: { bounded: true }
 end

--- a/lib/active_date_range.rb
+++ b/lib/active_date_range.rb
@@ -16,7 +16,7 @@ require "active_date_range/validators" if defined?(ActiveModel)
 
 module ActiveDateRange
   def self.deprecator
-    @deprecator ||= ActiveSupport::Deprecation.new("0.6.0", "ActiveDateRange")
+    @deprecator ||= ActiveSupport::Deprecation.new("in a future version", "ActiveDateRange")
   end
 
   class Error < StandardError; end

--- a/lib/active_date_range.rb
+++ b/lib/active_date_range.rb
@@ -15,6 +15,10 @@ require "active_date_range/active_model_type"
 require "active_date_range/validators" if defined?(ActiveModel)
 
 module ActiveDateRange
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new("0.6.0", "ActiveDateRange")
+  end
+
   class Error < StandardError; end
   class InvalidDateRange < Error; end
   class InvalidAddition < Error; end

--- a/lib/active_date_range.rb
+++ b/lib/active_date_range.rb
@@ -15,10 +15,6 @@ require "active_date_range/active_model_type"
 require "active_date_range/validators" if defined?(ActiveModel)
 
 module ActiveDateRange
-  def self.deprecator
-    @deprecator ||= ActiveSupport::Deprecation.new("in a future version", "ActiveDateRange")
-  end
-
   class Error < StandardError; end
   class InvalidDateRange < Error; end
   class InvalidAddition < Error; end

--- a/lib/active_date_range/active_model_type.rb
+++ b/lib/active_date_range/active_model_type.rb
@@ -7,15 +7,7 @@ module ActiveDateRange
     # raising:
     #
     #   attribute :period, :date_range, safe_parse: true
-    def initialize(safe_parse: false, safe: nil)
-      unless safe.nil?
-        ActiveDateRange.deprecator.warn(
-          "The safe: option is deprecated and will be removed in a future version. " \
-          "Use safe_parse: instead."
-        )
-        safe_parse = safe
-      end
-
+    def initialize(safe_parse: false)
       @safe_parse = safe_parse
       super()
     end

--- a/lib/active_date_range/active_model_type.rb
+++ b/lib/active_date_range/active_model_type.rb
@@ -2,17 +2,28 @@
 
 module ActiveDateRange
   class DateRangeType < ActiveModel::Type::String
-    # Pass <tt>safe: true</tt> for attributes fed by input you don't control, like a query
-    # parameter. The attribute then casts to nil instead of raising:
+    # Pass <tt>safe_parse: true</tt> for attributes fed by input you don't control, like a query
+    # parameter. The attribute then casts through .safe_parse, so it returns nil instead of
+    # raising:
     #
-    #   attribute :period, :date_range, safe: true
-    def initialize(safe: false)
-      @safe = safe
+    #   attribute :period, :date_range, safe_parse: true
+    def initialize(safe_parse: false, safe: nil)
+      unless safe.nil?
+        ActiveDateRange.deprecator.warn(
+          "The safe: option is deprecated and will be removed from ActiveDateRange 0.6.0. " \
+          "Use safe_parse: instead."
+        )
+        safe_parse = safe
+      end
+
+      @safe_parse = safe_parse
       super()
     end
 
     def cast(value)
-      @safe ? ActiveDateRange::DateRange.safe_parse(value) : ActiveDateRange::DateRange.parse(value)
+      return ActiveDateRange::DateRange.safe_parse(value) if @safe_parse
+
+      ActiveDateRange::DateRange.parse(value)
     end
   end
 end

--- a/lib/active_date_range/active_model_type.rb
+++ b/lib/active_date_range/active_model_type.rb
@@ -10,7 +10,7 @@ module ActiveDateRange
     def initialize(safe_parse: false, safe: nil)
       unless safe.nil?
         ActiveDateRange.deprecator.warn(
-          "The safe: option is deprecated and will be removed from ActiveDateRange 0.6.0. " \
+          "The safe: option is deprecated and will be removed in a future version. " \
           "Use safe_parse: instead."
         )
         safe_parse = safe

--- a/lib/active_date_range/version.rb
+++ b/lib/active_date_range/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveDateRange
-  VERSION = "0.5.4"
+  VERSION = "0.6.0"
 end

--- a/lib/active_date_range/version.rb
+++ b/lib/active_date_range/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveDateRange
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end

--- a/test/active_date_range/active_model_type_test.rb
+++ b/test/active_date_range/active_model_type_test.rb
@@ -22,27 +22,43 @@ class ActiveDateRangeAttributesTest < ActiveSupport::TestCase
     assert_raises(ActiveDateRange::InvalidDateRangeFormat) { report.period }
   end
 
-  class SafeTestReport
+  class SafeParseTestReport
     include ActiveModel::Attributes
 
-    attribute :period, :date_range, safe: true
+    attribute :period, :date_range, safe_parse: true
   end
 
-  def test_safe_date_range_conversion
-    report = SafeTestReport.new
+  def test_safe_parse_date_range_conversion
+    report = SafeParseTestReport.new
     report.period = "this_month"
     assert_equal ActiveDateRange::DateRange.this_month, report.period
   end
 
-  def test_safe_date_range_conversion_returns_nil
-    report = SafeTestReport.new
+  def test_safe_parse_date_range_conversion_returns_nil
+    report = SafeParseTestReport.new
     report.period = "unknown"
     assert_nil report.period
   end
 
-  def test_safe_date_range_conversion_returns_nil_for_reversed_range
-    report = SafeTestReport.new
+  def test_safe_parse_date_range_conversion_returns_nil_for_reversed_range
+    report = SafeParseTestReport.new
     report.period = "202503..202501"
+    assert_nil report.period
+  end
+
+  def test_deprecated_safe_option_still_works
+    report_class = nil
+
+    assert_deprecated("safe_parse", ActiveDateRange.deprecator) do
+      report_class = Class.new do
+        include ActiveModel::Attributes
+
+        attribute :period, :date_range, safe: true
+      end
+    end
+
+    report = report_class.new
+    report.period = "unknown"
     assert_nil report.period
   end
 end

--- a/test/active_date_range/active_model_type_test.rb
+++ b/test/active_date_range/active_model_type_test.rb
@@ -45,20 +45,4 @@ class ActiveDateRangeAttributesTest < ActiveSupport::TestCase
     report.period = "202503..202501"
     assert_nil report.period
   end
-
-  def test_deprecated_safe_option_still_works
-    report_class = nil
-
-    assert_deprecated("safe_parse", ActiveDateRange.deprecator) do
-      report_class = Class.new do
-        include ActiveModel::Attributes
-
-        attribute :period, :date_range, safe: true
-      end
-    end
-
-    report = report_class.new
-    report.period = "unknown"
-    assert_nil report.period
-  end
 end


### PR DESCRIPTION
On an attribute declaration, `safe: true` reads as a claim that the value is trusted, which is the opposite of the truth, since the option exists precisely for input you don't control. It describes how the value is *parsed*, not what the value is. Naming it after the method it uses removes the ambiguity:

```ruby
attribute :period, :date_range, safe_parse: true
```

This is a breaking change, released as 0.6.0, so caution when updating: `safe:` now raises an `ArgumentError` instead of being quietly accepted.